### PR TITLE
#152796603 Replace-UI-authentication-screen

### DIFF
--- a/public/css/elendil-style.css
+++ b/public/css/elendil-style.css
@@ -180,13 +180,12 @@ button[disabled]{
 .footer a:hover {
   color: #FF8800;
 }
-
-  
+ 
 [page="signup"] {
   background-size: cover;
   overflow-x: hidden;
+  padding-bottom: 3%;
 }
-
 
 .main {
   margin: 5rem auto;
@@ -199,7 +198,7 @@ button[disabled]{
 
 .avatar-list {
   padding-left: 0px;
-  margin-left: 3%;
+  margin-left: 5%;
   overflow: hidden;
 }
 
@@ -219,10 +218,10 @@ ul, ol {
 }
 
 .avatar-list img {
-  max-width: 45px;
+  max-width: 50px;
 }
 .avatar-list img {
-  max-width: 30%;
+  max-width: 45%;
 }
 .avatar-list img {
   vertical-align: middle;
@@ -236,6 +235,7 @@ ul, ol {
 
 .avatar-list li {
   list-style-type: none;
+  padding: 6px;
 }
 
 .custom-button {
@@ -247,6 +247,11 @@ ul, ol {
 
 .social-icons {
   border-radius: 20px;
+}
+
+.social-signup {
+  text-align: center;
+  padding-bottom: 2%;
 }
 
 .social-signup img {
@@ -267,7 +272,7 @@ ul, ol {
   
 .input-control {
   margin: 0 auto;
-  width: 300px;
+  width: 88%;
 }
   
 .cover img {
@@ -296,16 +301,17 @@ input[type="email"]:focus {
 }
 
 .avatar {
-  padding-top: 5px;
+  padding: 3%;
 }
 
-.signin-heading {
-  margin-top: 50px;
-  margin-right: 150px;
+#contain-avatars {
+  padding: 5%;
 }
+
 
 .sign-error {
   margin-left: 12px;
+  padding: 4%;
   font-family: arial;
 }
 
@@ -408,6 +414,82 @@ margin-top: 50px;
 
 .text-border {
   padding-right: 8em;
+}
+
+/* latest */
+
+.top {
+  background-color: rgb(252, 249, 243);
+  margin-top: -5px;
+}
+
+.sign-head {
+  max-width: 35%;
+  margin-left: auto;
+  margin-right: auto
+}
+.form-head {
+  background-color: #256188; 
+  color: #FFF;
+  margin-top: 8em;
+  padding: 25px;
+}
+
+.text-mv {
+  text-align: center;
+  margin-top: 10px;
+}
+
+.form-center {
+  text-align: center;
+}
+
+.btn-sign {
+  background: #F6A623; 
+  color: #FFF;
+  margin-left: 43%;
+  
+
+}
+
+button { 
+  margin-top: 2em;
+  margin-bottom: 0;
+}
+
+@media (max-width: 780px) {
+  .sign-head {
+    max-width: 85%;
+  }
+  .btn-sign {
+    position: relative;
+    right: 20px;
+  }
+  #contain-avatars {
+    padding: 5px;
+  }
+  .avatar-list img {
+    max-width: 20px;
+  }
+  .avatar-list img {
+    max-width: 25%;
+  }
+  .avatar-list img {
+    border-width: 0px;
+    border-style: initial;
+    border-color: initial;
+    border-image: initial;
+  }
+
+  .avatars {
+    position: relative;
+    float: left;
+    border-radius: 3px;
+  }
+  
+  .avatar-list li {
+    list-style-type: none;
+  }
 }
 
 

--- a/public/views/signin.html
+++ b/public/views/signin.html
@@ -1,49 +1,50 @@
 <div page="signup" ng-controller="IndexController">
-  
-    <div class="main row">
-      <div class="col-6 cover">
-        <img src="../img/hoyleback.jpg" alt="side auth card image" width="350px">
-      </div>
-      <div class="col-6 auth">
-        <div class="text-center">
-          <h3 class="dark-grey-text">
-            <strong>Sign In</strong>
-          </h3>
-          <p>Don't have an account?
-            <strong><a href="/signup">Sign Up</a></strong>
-          </p>
+  <div>
+    <div>
+      <div class="sign-head">
+        <div class="form-head">
+          <h4 class="form-center head-text">Sign in</h4>
         </div>
-        <div class="sign-error alert alert-danger alert alert-danger" ng-show="showError() === 'invalid'">
-          <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-          <p class="text-red">Please check your username/password and try again.</p>
-        </div>
-        <div class="sign-error alert alert-danger alert alert-danger" ng-show="showError() === 'undefined'">
-          <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-          <p class="text-red">Please check your username/password and try again.</p>
-        </div>
-        <form class="form-field" ng-submit="login()">
-          <div class="input-control">
-            <label for="email" id="labelled">Email</label>
-            <input ng-model="email" type="email" name="email" placeholder="email" id="email" required novalidate>
-          </div>
-          <div class="input-control">
-            <label for="password" id="labelled">Password</label>
-            <input ng-model="password" type="password" placeholder="password" id="password" name="password" required novalidate>
-          </div>
-          <button type="submit" class="btn btn-default btn-block custom-button">Sign In</button>
-        </form>
-        <div class="col-12">
-            <div class="social-signup">
-              <p class="signin-heading"> Or SignIn With</p>
-              <a href="/auth/google"><img class="social-icons" src="../img/icon/google.png" alt="Google"></a>
-              <a href="/auth/facebook"><img class="social-icons" src="../img/icon/facebook.png" alt="Facebook"></a>
-              <a href="/auth/twitter"><img class="social-icons" src="../img/icon/twitter.png" alt="Twitter"></a>
+        <div>
+          <div class="top">
+            <div class="text-center">
+              <p>Don't have an account?
+                <strong><a href="#!/signup">Sign up</a></strong>
+              </p>
             </div>
-        </div>
-        <div class="signin-heading">
-          <a href="#" title="BackHome" class="text-home">Back Home</a>
+             <div class="sign-error alert alert-danger" ng-show="showError() === 'undefined'">
+              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+              <span class="text-red">Please check your username/password and try again.</span>
+            </div>
+             <div class="sign-error alert alert-danger" ng-show="showError() === 'invalid'">
+              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+              <span class="text-red">Please check your username/password and try again.</span>
+            </div>
+            <form class="form-field mr-auto" ng-submit="login()">
+              <div class="input-control">
+                <label for="email" id="label">Email</label>
+                <input type="email" ng-model="email" placeholder="john@doe.com" id="email" required novalidate>
+              </div>
+              <div class="input-control">
+                <label for="password" id="label">Password</label>
+                <input type="password" ng-model="password" placeholder="password" id="password" required novalidate>
+              </div>
+              <button type="submit" class="btn btn-md btn-sign">Sign in</button>
+            </form>
+            <div>
+              <h5 class="text-mv"> OR </h5>
+              <br>
+              <div class="social-signup">
+                <span class="signin-heading">Sign in with</span>
+                <a href="/auth/google"><img class="social-icons" src="../img/icon/google.png" alt="Google"></a>
+                <a href="/auth/facebook"><img class="social-icons" src="../img/icon/facebook.png" alt="Facebook"></a>
+                <a href="/auth/twitter"><img class="social-icons" src="../img/icon/twitter.png" alt="Twitter"></a>
+                <a href="/auth/github"><img class="social-icons" src="../img/icon/github.png" alt="Github"></a>
+  
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  
-  </div>
+  </di>

--- a/public/views/signup.html
+++ b/public/views/signup.html
@@ -1,119 +1,75 @@
 <div page="signup" ng-controller="IndexController">
-  <div class="main row">
-    <div class="col-6 cover">
-      <img src="../img/hoyleback.jpg" alt="side auth card image" width="350px">
-    </div>
-    <div class="col-6 auth">
-      <div class="text-center">
-        <h3 class="dark-grey-text">
-          <strong>Sign up</strong>
-        </h3>
-        <p>Have an account?
-          <strong><a href="/signin">Sign In</a></strong>
-        </p>
-      </div>
-      <span class="sign-error alert alert-danger alert alert-danger" ng-show="showError() === 'existingUser'">
-        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-        <p class="text-red">A user already exists with that email</p>
-      </span>
-      <span class="sign-error alert alert-danger alert alert-danger" ng-show="showError() === 'invalid'">
-        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-        <p class="text-red">Invalid credentials</p>
-      </span>
-      <span class="sign-error alert alert-danger alert alert-danger" ng-show="showError() === 'undefined'">
-        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-        <p class="text-red">A user already exists with that email</p>
-      </span>
-      <form class="form-field" ng-submit="signup()">
-        <div class="input-control">
-          <label for="fullname" id="label">Fullname</label>
-          <input ng-model="name" type="text"id="name" name="name" placeholder="fullname" id="fullname" required>
+  <div>
+    <div>
+      <div class="sign-head">
+        <div class="form-head">
+          <h4 class="form-center head-text">Sign up</h4>
         </div>
-        <div class="input-control">
-          <label for="email" id="label">Email</label>
-          <input ng-model="email" type="email" id="email" type="email" name="email" placeholder="email" id="email" required>
+        <div>
+          <div class="top">
+            <div class="text-center">
+              <p>Have an account?
+                <strong><a href="#!/signin">Sign In</a></strong>
+              </p>
+            </div>
+            <div class="sign-error alert alert-danger" ng-show="showError() === 'undefined'">
+              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+              <span class="text-red">A user already exists with that email</span>
+            </div>
+            <span class="sign-error alert alert-danger" ng-show="showError() === 'invalid'">
+              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+              <p class="text-red">Invalid credentials</p>
+            </span>
+            <span class="sign-error alert alert-danger" ng-show="showError() === 'existingUser'">
+              <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+              <p class="text-red">A user already exists with that email</p>
+            </span>
+            <form class="form-field mr-auto" ng-submit="signup()" method="post">
+              <div class="control-group">
+                <div class="input-control">
+                  <label for="fullname" id="label">Full Name</label>
+                  <input ng-model="name" type="text" placeholder="Full Name" id="fullname" required>
+                </div>
+              </div>
+              <div class="control-group">
+                <div class="input-control">
+                  <label for="email" id="label">Email</label>
+                  <input ng-model="email" type="email" placeholder="john@doe.com" id="email" required>
+                </div>
+              </div>
+              <div class="input-control">
+                <div class="control-group">
+                  <label for="password" id="label">Password</label>
+                  <input ng-model="password" type="password" placeholder="password" id="password" required>
+                </div>
+              </div>
+              <div id="contain-avatars">
+                <h6>Choose an Avatar</h6>
+                <ul ng-controller="IndexController" class="avatar-list">
+                  <li ng-repeat="avatar in avatars" class="avatars ng-scope">
+                      <input name="avatar" type='radio' value="{{$index}}">
+                        <img ng-src="{{avatar}}">
+                      </input>
+                  </li>
+                </ul>
+              </div>
+                <button class="btn btn-md btn-sign" type="submit">Sign up</button>
+            </form>
+            <div>
+              
+              <h5 class="text-mv"> OR </h5>
+              <br>
+              <div class="social-signup">
+                <span class="signin-heading">Sign up with</span>
+                <a href="/auth/google"><img class="social-icons" src="../img/icon/google.png" alt="Google"></a>
+                <a href="/auth/facebook"><img class="social-icons" src="../img/icon/facebook.png" alt="Facebook"></a>
+                <a href="/auth/twitter"><img class="social-icons" src="../img/icon/twitter.png" alt="Twitter"></a>
+                <a href="/auth/github"><img class="social-icons" src="../img/icon/github.png" alt="Github"></a>
+  
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="input-control">
-          <label for="password" id="label">Password</label>
-          <input ng-model="password" type="password" type="password" name="password" placeholder="password" id="password" required>
-        </div>
-        <h6 class="avatar">Choose an avatar</h6>
-        <ul class="avatar-list">
-          <div class="d-flex flex-row">
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="0">
-              <img src="../img/chosen/E01.png">
-            </li>
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="1">
-              <img src="../img/chosen/F01.png">
-            </li>
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="2">
-              <img src="../img/chosen/FA04.png">
-            </li>
-          </div>
-          <div class="d-flex flex-row">
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="3">
-              <img src="../img/chosen/FB03.png">
-            </li>
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="4">
-              <img src="../img/chosen/FC01.png">
-            </li>
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="5">
-              <img src="../img/chosen/FD01.png">
-            </li>
-          </div>
-          <div class="d-flex flex-row">
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="6">
-              <img src="../img/chosen/FE01.png">
-  
-            </li>
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="7">
-              <img src="../img/chosen/FH03.png">
-  
-            </li>
-  
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="8">
-              <img src="../img/chosen/FI02.png">
-            </li>
-          </div>
-          <div class="d-flex flex-row">
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="9">
-              <img src="../img/chosen/H01.png">
-  
-            </li>
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="10">
-              <img src="../img/chosen/J01.png">
-            </li>
-            <li class="avatars p-1">
-              <input ng-model="avatar" name="avatar" type="radio" value="11">
-              <img src="../img/chosen/M05.png">
-            </li>
-          </div>
-        </ul>
-        <button type="submit" class="btn btn-default btn-block custom-button" type="submit">Sign Up</button>
-      </form>
-    </div>
-    <div class="col-12 back-home">
-      <div class="social-signup text-center">
-        <p class="signin-heading"> Or Signup With 
-          <a href="/auth/google"><img class="social-icons" src="../img/icon/google.png" alt="Google"></a>
-          <a href="/auth/facebook"><img class="social-icons" src="../img/icon/facebook.png" alt="Facebook"></a>
-          <a href="/auth/twitter"><img class="social-icons" src="../img/icon/twitter.png" alt="Twitter"></a>
-      </p>
-      </div>
-      <div class="text-center">
-        <a href="/" title="BackHome" class="text-home">Back Home</a>
       </div>
     </div>
   </div>
-</div>


### PR DESCRIPTION
#### What does this PR do?
- Allows users to see a better designed UI on the signin and signup pages
#### Description of Task to be completed?
- Old UI for the pages will be replaced with the newly designed UI
#### How should this be manually tested?
- Navigate to the app on heroku
- From the landing page, click on the sign in or sign up page to access the new UI
#### Any background context you want to provide?
- The new UI is based on the feedback from the PO
#### What are the relevant pivotal tracker stories?
#152796603
#### Screenshots (if appropriate)
<img width="631" alt="screen shot 2017-12-13 at 16 56 38" src="https://user-images.githubusercontent.com/17340003/34015250-2aed4898-e11e-11e7-86ce-d75027c975eb.png">
<img width="730" alt="screen shot 2017-12-13 at 16 56 13" src="https://user-images.githubusercontent.com/17340003/34016110-f8395cb8-e120-11e7-91c6-541594bc24c0.png">
#### Questions:
N/A