### PR TITLE
#153684480 Fix bug in categorising by region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 package-lock.json
 gruntfile
 seeders/
+scratch/

--- a/app/controllers/gamelog.js
+++ b/app/controllers/gamelog.js
@@ -14,6 +14,7 @@ module.exports.saveGameLog = function (req, res) {
   gamelog.gameId = req.body.gameID;
   gamelog.players = req.body.players;
   gamelog.winner = req.body.winner;
+  gamelog.rounds = req.body.rounds;
   gamelog.save((err) => {
     if (err) {
       return res.json({ message: 'An error occured' });

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -1,4 +1,5 @@
 /* jshint esversion: 6 */
+/* eslint-disable */
 const jwt = require('../../config/jwt');
 const nodemailer = require('nodemailer');
 
@@ -462,4 +463,9 @@ exports.deleteFriend = (req, res) => {
       message: 'Friend removed sucessfully!'
     });
   });
+};
+
+exports.setRegion = function(req, res) {
+  localStorage.setItem('region', req.body.region);
+  return res.send({ message: 'Region set' });
 };

--- a/app/models/gamelog.js
+++ b/app/models/gamelog.js
@@ -30,6 +30,9 @@ const GamelogSchema = new Schema({
     type: Object,
     default: '',
   },
+  rounds: {
+    type: String
+  }
 });
 
 const Gamelog = mongoose.model('Gamelog', GamelogSchema);

--- a/app/models/question.js
+++ b/app/models/question.js
@@ -29,11 +29,10 @@ let QuestionSchema = new Schema({
     default: '',
     trim: true
   },
-  region: {
+  location: {
     type: String,
     default: '',
     trim: true,
-    lowercase: true
   }
 });
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -16,6 +16,7 @@ module.exports = (app, passport, auth) => {
   // search and invite users
   app.get('/api/search/users', checkToken.validateToken, users.searchUsers);
   app.post('/api/users/invite', users.sendInvites);
+  app.post('/api/region', users.setRegion);
 
   // Add friends
   app.put('/api/user/friends', checkToken.validateToken, users.addFriend);

--- a/config/socket/game.js
+++ b/config/socket/game.js
@@ -20,9 +20,7 @@ var guestNames = [
   "The Spleen",
   "Dingle Dangle"
 ];
-
-let newRegion = '';
-
+let newRegion = localStorage.getItem('region');
 function Game(gameID, io) {
   this.io = io;
   this.gameID = gameID;
@@ -37,10 +35,10 @@ function Game(gameID, io) {
   this.pointLimit = 5;
   this.state = "awaiting players";
   this.round = 0;
+  this.region = '';
   this.questions = null;
   this.answers = null;
   this.curQuestion = null;
-  this.region = '';
   this.timeLimits = {
     stateChoosing: 21,
     stateJudging: 16,
@@ -60,6 +58,7 @@ function Game(gameID, io) {
 
 Game.prototype.payload = function() {
   var players = [];
+  var self = this;
   this.players.forEach(function(player,index) {
     players.push({
       hand: player.hand,
@@ -70,7 +69,8 @@ Game.prototype.payload = function() {
       avatar: player.avatar,
       premium: player.premium,
       socketID: player.socket.id,
-      color: player.color
+      color: player.color,
+      region: this.region
     });
   });
   return {
@@ -126,9 +126,10 @@ Game.prototype.prepareGame = function() {
       playerMinLimit: this.playerMinLimit,
       playerMaxLimit: this.playerMaxLimit,
       pointLimit: this.pointLimit,
-      timeLimits: this.timeLimits
-    });
-
+      timeLimits: this.timeLimits,
+      region: this.region
+    }
+  );
   var self = this;
   async.parallel([
     this.getQuestions,
@@ -138,9 +139,9 @@ Game.prototype.prepareGame = function() {
       if (err) {
         console.log(err);
       }
-      self.questions = results[0];
-      self.answers = results[1];
-
+      self.questions = results[0].filter(result => result.location === localStorage.getItem('region'));
+      self.answers = results[1].filter(result => result.location === localStorage.getItem('region'));
+      
       self.startGame();
     });
 };
@@ -151,7 +152,6 @@ Game.prototype.startGame = function() {
   this.shuffleCards(this.answers);
   this.changeCzar(this);
   this.sendUpdate();
-  //this.stateChoosing(this);
 };
 
 Game.prototype.changeCzar = (self) => {
@@ -168,7 +168,6 @@ Game.prototype.changeCzar = (self) => {
 
 Game.prototype.sendUpdate = function() {
   this.io.sockets.in(this.gameID).emit('gameUpdate', this.payload());
-  newRegion = this.region;
 };
 
 Game.prototype.stateChoosing = function(self) {
@@ -269,6 +268,7 @@ Game.prototype.stateEndGame = function(winner) {
       gameID: this.gameID,
       winner: winnerProfile,
       players: allPlayers,
+      rounds: this.round
     }
   );
 };

--- a/config/socket/socket.js
+++ b/config/socket/socket.js
@@ -109,22 +109,21 @@ module.exports = function (io) {
           // If the user's ID isn't found (rare)
           player.username = 'Guest';
           player.avatar = avatars[Math.floor(Math.random() * 4) + 12];
-          player.region = data.region; // add player's region
+          player.region = data.region;
         } else {
           player.userID = user._id;
           player.username = user.name;
           player.email = user.email;
           player.premium = user.premium || 0;
           player.avatar = user.avatar || avatars[Math.floor(Math.random() * 4) + 12];
-          player.region = data.region; // add player's region
+          player.region = data.region;
         }
-        getGame(player, socket, data.room, data.createPrivate);
+        getGame(player, socket, data.room, data.createPrivate, data.region);
       });
     } else {
       // If the user isn't authenticated (guest)
       player.username = 'Guest';
       player.avatar = avatars[Math.floor(Math.random() * 4) + 12];
-      player.region = data.region; // add player's region
       getGame(player, socket, data.room, data.createPrivate);
     }
   };
@@ -191,14 +190,6 @@ module.exports = function (io) {
       game.sendUpdate();
     } else {
       game = gamesNeedingPlayers[0];
-      if (game.region !== player.region) {
-        if (gamesNeedingPlayers.length > 1) {
-          game = gamesNeedingPlayers[1];
-        } else {
-          fireGame(player, socket, true);
-          return;
-        }
-      }
       allPlayers[socket.id] = true;
       game.players.push(player);
       console.log(socket.id, 'has joined game', game.gameID);
@@ -260,5 +251,4 @@ module.exports = function (io) {
     }
     socket.leave(socket.gameID);
   };
-
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7871,6 +7871,31 @@
         }
       }
     },
+    "node-localstorage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.0.tgz",
+      "integrity": "sha1-LkNqro3Mms6XtDxlwWwNV3vgpVw=",
+      "requires": {
+        "write-file-atomic": "1.3.4"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        }
+      }
+    },
     "node-sass": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
@@ -11660,6 +11685,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "sntp": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "mean-logger": "~0.0.1",
     "mongodb": "^2.2.33",
     "mongoose": "~4.12.2",
+    "node-localstorage": "^1.3.0",
     "nodemailer": "^4.4.1",
     "passport": "~0.1.17",
     "passport-facebook": "~2.0.0",

--- a/public/css/game.css
+++ b/public/css/game.css
@@ -305,7 +305,8 @@ body {
               font-family: 'Bangla MN' }
               #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
                 font-size: 1rem;
-                margin-top: 1.5rem;
+                margin-top: .4rem;
+                float: left;
                 margin-bottom: 0; }
                 @media only screen and (min-width: 521px) and (max-width: 768px) {
                   #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -47,7 +47,18 @@ angular.module('mean.system')
          .text('Oops! Can\'t start game now, you need a minimum of (3) players to get started');
         infoModal.modal('show');
       } else {
-        game.startGame();
+        if ($scope.region === undefined || $scope.region === '') {
+        const infoModal = $('#infoModal');
+          infoModal.find('.modal-title')
+          .text('Select region');
+        infoModal.find('.modal-body')
+         .text('Oops! Can\'t start game, you probably forgot to select a region');
+        infoModal.modal('show');
+        } else {
+          $scope.data = { region: $scope.region };
+          $http.post('/api/region', $scope.data);
+          game.startGame();
+        }
       }
     };
 
@@ -382,7 +393,7 @@ angular.module('mean.system')
         const myModal = $('#start-modal');
         myModal.modal('show');
       }
-
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
       if (game.state === 'game dissolved') {
         playTone('error', 0.4);
         $('#start-modal').modal('hide');

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -64,8 +64,7 @@ angular.module('mean.system')
           if ($scope.region === undefined || $scope.region === '') {
             $scope.error = 'Select a region first!';
           } else {
-            $('#close').click();
-            $window.location.path('/app');
+            $window.location.href = '/app';
           }
         };
 
@@ -73,7 +72,6 @@ angular.module('mean.system')
           if ($scope.region === undefined || $scope.region === '') {
             $scope.error = 'Select a region first!';
           } else {
-            $('#close').click();
             $window.location.href = '/play';
           }
         };
@@ -82,7 +80,6 @@ angular.module('mean.system')
           if ($scope.region === undefined || $scope.region === '') {
             $scope.error = 'Select a region first!';
           } else {
-            $('#close').click();
             $window.location.href = '/play?custom';
           }
         };

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -68,6 +68,7 @@ angular.module('mean.system')
     game.playerMaxLimit = data.playerMaxLimit;
     game.pointLimit = data.pointLimit;
     game.timeLimits = data.timeLimits;
+    game.region = data.region;
   });
 
   game.broadcastNotification = function(data) {
@@ -203,7 +204,8 @@ angular.module('mean.system')
     createPrivate = createPrivate || false;
     const token = localStorage.getItem('token');
     var userID = !!window.user ? user._id : 'unauthenticated';
-    socket.emit(mode,{userID: userID, room: room, createPrivate: createPrivate, token});
+    var region = localStorage.getItem('region');
+    socket.emit(mode,{userID: userID,region: region, room: room, createPrivate: createPrivate, token});
   };
 
   game.startGame = function() {

--- a/public/views/dashboard.html
+++ b/public/views/dashboard.html
@@ -3,29 +3,28 @@
     <span class="navbar-toggler-icon"></span>
   </button>
   <a class="navbar-brand" href="#!"> <img src="../img/cfh-logo.png" style="width: 60%;" ></a>
-  <div class="collapse navbar-collapse" id="gameOptions">
-    <ul class="navbar-nav ml-auto" style="position:relative; width: 46% ">
-      <li ng-hide="showOptions">
-        <button 
-          ng-click="viewNotification()"
-          class="dropdown show"
-          style="
-          border: 0;
-          color: #FFF;
-          font-family: cursive;
-          font-size: 1.1rem;
-          cursor: pointer;
-          background: none;
-          margin-right: 10px;
-          width: 50px;
-          margin-right: 10px;"
-          >
-            <span ng-class="{ 'notification': notifications.length > 0  }">{{showOptions}}<i class="fa fa-bell" aria-hidden="true"></i> <sup style="top: -1.5em;">{{notifications.length}}</sup></span>
-          </button>            
-        </li> 
-    
+  <div div class="collapse navbar-collapse" id="gameOptions">
+    <ul class="navbar-nav ml-auto" style="position:relative; width: 42%; align-items: center">
+        <li ng-hide="showOptions">
+            <button 
+              ng-click="viewNotification()"
+              class="dropdown show"
+              style="
+              border: 0;
+              color: #FFF;
+              font-family: cursive;
+              font-size: 1.1rem;
+              cursor: pointer;
+              background: none;
+              margin-right: 10px;
+              width: 50px;
+              margin-bottom: 30px;"
+              >
+                <span ng-class="{ 'notification': notifications.length > 0  }">{{showOptions}}<i class="fa fa-bell" aria-hidden="true"></i> <sup style="top: -1.5em;">{{notifications.length}}</sup></span>
+              </button>            
+            </li>
       <li><a href="/tour" class="nav-item btn btn-sm" style="background: #FF8800; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer">Take a Tour</a></li>
-      <li ng-click="abandonGame()"><button class="nav-item btn btn-sm" style="background: #FF8800; color: #FFF; border-radius: 12px; margin-left: 14px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer">Abandon Game</button></li>
+      <li ng-click="abandonGame()"><button class="nav-item btn btn-sm" style="background: #FF8800; color: #FFF; border-radius: 12px; margin-left: 14px; margin-top: 0; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer">Abandon Game</button></li>
       <li>
         <a href="https://twitter.com/share" data-url="http://cfh.io" class="nav-item btn btn-sm" data-text="Cards for Humanity: A Game for Horrible People Desperately Trying to do Good" data-related="CFH_App" style="border-radius: 12px; margin-left: 15px; background: #00ACED; color: #FFF; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem">Tweet</a>
         <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -42,8 +42,8 @@
             <a style="background: #FF8800; color: #FFF; border-radius: 12px;font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem" ng-show="showOptions" class="nav-item nav-link active " href="#!/signup">Sign up</a>
             <a style="background: #FF8800; color: #FFF; border-radius: 12px;font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem" ng-show="showOptions" class="nav-item nav-link active" href="#!/signin">Sign in</a>
 
-            <a ng-hide="showOptions" class="nav-item nav-link" style="font-family: cursive;" href="#!/dashboard">Dashboard</a>
-            <a style="background: #FF8800; color: #FFF; border-radius: 12px;font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem" ng-hide="showOptions" class="nav-item nav-link active" ng-click="signOut()" href="/">Sign Out</a>
+            <a style="font-family: cursive; font-size: 1.1rem" ng-hide="showOptions" class="nav-item nav-link" href="#!/dashboard">Dashboard</a>
+            <a ng-hide="showOptions" class="nav-item nav-link active" ng-click="signOut()" href="/" style="background: #FF8800; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer">Sign Out</a>
                
           </div>
         </div>
@@ -67,15 +67,15 @@
                   <label for="region"></label>
                   <select ng-model="region" class="one-whole" name="region" id="region">
                     <option value="">Choose a region</option>
-                    <option value="africa">Africa</option>
-                    <option value="others">Worldwide</option>
+                    <option value="Africa">Africa</option>
+                    <option value="Global">Worldwide</option>
                   </select>
                 </div>
                 <span ng-show="showOptions">
                   <button class="btn btn-default home-button custom-button text-white" ng-click="playWithStrangers()">PLAY GAME</button>
                 </span>
                 <span ng-hide="showOptions">
-                  <button class="btn btn-default home-button custom-button text-white" ng-click="playWithStrangers()">PLAY WITH STRANGERS</button>
+                  <button class="btn btn-default home-button custom-button text-white" ng-click="playWithStrangers()">PLAY GAME</button>
                   <button type="submit" class="btn btn-default home-button custom-button text-white" ng-click="playWithFriends()">PLAY WITH FRIENDS</button>
                 </span>
                 <button id="close" class="btn btn-default home-button custom-button text-white" data-dismiss="modal">CANCEL</button>
@@ -91,18 +91,18 @@
       </div>
   
   <!-- Header Start -->
-  <div class="header" id="home">
+  <div ng-controller="IndexController" class="header" id="home">
     <div class="header-text">
       <p>A game for horrible <br> people desperately trying to do good </p>
     </div>
     <div class="game-btn" ng-show="showOptions" id="how-to-play">
         <a href="/tour"><button type="button" class="btn btn-warning">Take a Tour</button></a>
-        <button type="button" class="btn btn-light" data-toggle="modal" data-target="#regionModal">Play as Guest</button>
+        <a href="/play" ng-click="playAsGuest()"><button type="button" class="btn btn-light">Play as Guest</button></a>
     </div>
 
     <div class="game-btn" ng-hide="showOptions">
-        <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#regionModal">Play Game with Strangers</button>
-        <button type="button" class="btn btn-light" data-toggle="modal" data-target="#regionModal">Play Game with Friends</button>
+        <a href="/play" ng-click="playWithStrangers()"><button type="button" class="btn" style="background: #fff; color:#FF8800; cursor: pointer">Play With Strangers</button></a>
+        <a href="/play?custom" ng-click="playWithFriends()"><button type="button" class="btn btn-warning" style="cursor: pointer">Play With Friends</button></a>
     </div>
 
     <div class="how-to-slider" style="margin-top: 8%">

--- a/public/views/start.html
+++ b/public/views/start.html
@@ -5,11 +5,11 @@
         <div class="modal-header" style="background-color: #256188; color: #FFF; border-top-right-radius: unset; border-top-left-radius: unset">
           <h4 class="modal-title" style="margin-right:auto; margin-left:auto; margin-top: .5rem; line-height: 1">Cards For Humanity</h4>
         </div>
-        <div class="modal-body">
+        <div class="modal-body" style="max-height: 250px">
           <span >
             <button
               ng-animate="{enter: 'animated fadeInLeft'}"
-              style="background: #FF8800; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer"
+              style="background: #FF8800; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer; margin-top: 0"
               ng-show="game.playerIndex === 0 || (game.joinOverride && game.players.length >= game.playerMinLimit)"
               ng-click="startGame()"
               class="btn btn-sm"
@@ -22,19 +22,23 @@
             <button
               ng-hide="game.players[game.playerIndex].email === null"
               ng-click="invitePlayers()"
-              style="background: #FF8800; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer"
+              style="background: #FF8800; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor:pointer; margin-top: 0"
               ng-disabled="game.players.length >= 12" 
               class="btn btn-sm">
               Invite Players
               
             </button>
           </span>
-          <br/><br/>
-          <img src="../img/loader_3.gif" style="height:80px" alt="">
-          <figcaption style="font-size: 14px; margin-top: 6px; color: #256188">Finding Players <br></figcaption>
-          <span style="font-size: 13px; font-weight: lighter; color: #256188"><p>{{game.players.length}} / {{game.playerMaxLimit}} player(s) found</p></span>
+          <div class="form-group" style="margin-bottom: .5rem">
+            <label for="region"></label>
+            <input ng-model="region" type="radio" value="Africa" style="position: absolute; top: 21.5%; left: 35%"></input><span style="font-size:1rem; color:#256188; position: absolute; top: 26%; left: 39%">Africa</span>
+            <input ng-model="region" type="radio" value="Global" style="position: absolute; top: 21.5%; left: 53%"></input><span style="font-size:1rem; color:#256188; position: absolute; top: 26%; left: 57%">Global</span>
+          </div>
+          <img src="../img/loader_3.gif" style="height:80px; margin-top: -2px; margin-bottom: 2px" alt="">
+          <div style="font-size: 14px; margin-top: 6px; color: #256188">Finding Players</div>
+          <span style="font-size: 13px; font-weight: lighter; color: #256188;"><p style="margin-top: 0; margin-bottom: 0">{{game.players.length}} / {{game.playerMaxLimit}} player(s) found</p></span>
         </div>
-        <div ng-show="link.slice(-3) !== 'app'" style="font-size: 13px; font-weight: lighter; margin-top: 6px; color: #256188">
+        <div ng-show="link.slice(-3) !== 'app'" style="font-size: 13px; font-weight: lighter; margin-top: 0; color: #256188">
           Give the following link to your friends so they can join your game:
           <br>
           {{link}}
@@ -43,7 +47,7 @@
           {{game.notification}}
         </div>
         <div class="modal-footer" style="background-color: #256188; color: #FFF; padding-top: 10px; padding-bottom: 10px">
-          <button style="background: #FF8800; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor: pointer" ng-click="abandonGame()" type="button" class="btn btn-sm" data-dismiss="modal">Exit Game</button>
+          <button style="background: #FF8800; margin-top: auto; color: #FFF; border-radius: 12px; font-family: cursive; font-size: 1.1rem; padding: .1rem 2rem; cursor: pointer" ng-click="abandonGame()" type="button" class="btn btn-sm" data-dismiss="modal">Exit Game</button>
         </div>
       </div>
     </div>

--- a/server.js
+++ b/server.js
@@ -7,7 +7,10 @@ const express = require('express'),
   fs = require('fs'),
   passport = require('passport'),
   logger = require('mean-logger'),
-  io = require('socket.io');
+  io = require('socket.io'),
+  LocalStorage = require('node-localstorage').LocalStorage;
+
+  localStorage = new LocalStorage('./scratch');
 
 
 require('dotenv').config();


### PR DESCRIPTION
#### What does this PR do?
* Use region specific questions and answers based on region selected for a game session
* Save the number of rounds for each game log
* Fix component alignment issues on the gaming screen UI
#### Description of Task to be completed?
* Change the implementation of region selection by moving to region selection to the gaming page
* Have radio buttons displayed on the game start modal for region selection
* Simulate local storage using `node-localstorage` to set selected region
* Include game rounds in the saved game log history
* Fix component styles on gaming screen
#### How should this be manually tested?
Visit the app through the link `https://elendil-cfh-staging.herokuapp.com`
* Login, start a game session and invite other players
* Select preferred region `Global` or `Africa` using the radio buttons on the pop-up modal
* Click on the `start game` button
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
#153684480
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/26303683/34154822-2d82fa16-e4b7-11e7-8582-d07a75fa7b50.png)

![image](https://user-images.githubusercontent.com/26303683/34154784-070c4086-e4b7-11e7-822a-d5fe95dcf67e.png)
